### PR TITLE
Make favicon public for MFA sample

### DIFF
--- a/servlet/spring-boot/java/authentication/username-password/mfa/src/main/java/example/SecurityConfig.java
+++ b/servlet/spring-boot/java/authentication/username-password/mfa/src/main/java/example/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
 		// @formatter:off
 		http
 			.authorizeHttpRequests((authorize) -> authorize
+				.antMatchers("/favicon.ico").permitAll()
 				.mvcMatchers("/second-factor", "/third-factor").access(mfaAuthorizationManager)
 				.anyRequest().authenticated()
 			)


### PR DESCRIPTION
This resolves issue https://github.com/spring-projects/spring-security-samples/issues/63 with the MFA sample.  Even though the resource doesn't exist, chrome (and probably other browsers) will request the favicon after requesting the "second-factor" page.  Requests for the favicon prevented proceeding past the second-factor page, never hitting the POST to "second-factor".  Instead, the sample prompts for the username, again.

Exposing favicon (even though it doesn't exist) resolves the issue.