### PR TITLE
use Kotlin DSL for Servlet Security Configuration

### DIFF
--- a/servlet/spring-boot/kotlin/hello-security/src/main/kotlin/org/springframework/security/samples/config/SecurityConfig.kt
+++ b/servlet/spring-boot/kotlin/hello-security/src/main/kotlin/org/springframework/security/samples/config/SecurityConfig.kt
@@ -20,6 +20,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.provisioning.InMemoryUserDetailsManager
@@ -34,11 +35,15 @@ class SecurityConfig {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
-        http.authorizeRequests()
-            .requestMatchers("/css/**").permitAll()
-            .requestMatchers("/user/**").hasAuthority("ROLE_USER")
-            .and()
-            .formLogin().loginPage("/log-in")
+        http {
+            authorizeRequests {
+                authorize("/css/**", permitAll)
+                authorize("/user/**", hasAuthority("ROLE_USER"))
+            }
+            formLogin {
+                loginPage = "/log-in"
+            }
+        }
         return http.build()
     }
 

--- a/servlet/spring-boot/kotlin/hello-security/src/test/kotlin/org/springframework/security/samples/KotlinApplicationTests.kt
+++ b/servlet/spring-boot/kotlin/hello-security/src/test/kotlin/org/springframework/security/samples/KotlinApplicationTests.kt
@@ -16,9 +16,7 @@
 
 package org.springframework.security.samples
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -26,32 +24,33 @@ import org.springframework.mock.web.MockHttpSession
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin
 import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated
 import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest
 @AutoConfigureMockMvc
-class KotlinApplicationTests {
-
-    @Autowired
-    private lateinit var mockMvc: MockMvc
+class KotlinApplicationTests(@Autowired private val mockMvc: MockMvc) {
 
     @Test
     fun `index page is not protected`() {
-        this.mockMvc.perform(get("/"))
-                .andExpect(status().isOk())
+        this.mockMvc
+                .get("/")
+                .andExpect {
+                    status { isOk() }
+                }
     }
 
     @Test
     fun `protected page redirects to login`() {
-        val mvcResult = this.mockMvc.perform(get("/user/index"))
-                .andExpect(status().is3xxRedirection())
-                .andReturn()
-
-        assertThat(mvcResult.response.redirectedUrl).endsWith("/log-in")
+        this.mockMvc.get("/user/index")
+                .andExpect {
+                    status { is3xxRedirection() }
+                    header {
+                        redirectedUrlPattern("**/log-in")
+                    }
+                }
     }
 
     @Test


### PR DESCRIPTION
Update example to align w/ Spring Security documentation https://docs.spring.io/spring-security/reference/6.0.0-RC2/servlet/configuration/kotlin.html#kotlin-config-httpsecurity.4

Closes #92.