### PR TITLE
Use setup-java action to cache dependencies

### DIFF
--- a/.github/workflows/continuous-integraion-workflow.yml
+++ b/.github/workflows/continuous-integraion-workflow.yml
@@ -14,13 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          distribution: 'temurin'
+          cache: 'gradle'
       - name: Build with Gradle
         run: ./gradlew check --continue


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated `continuous-integration-workflow.yml` to cache dependencies using [actions/setup-java](https://github.com/actions/setup-java#caching-packages-dependencies). `setup-java@v3` or newer has caching **built-in**.

**AS-IS**

```yaml
- name: Set up JDK
  uses: actions/setup-java@v1
  with:
    java-version: '17'
- name: Cache Gradle packages
  uses: actions/cache@v2
  with:
    path: ~/.gradle/caches
    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
```

**TO-BE**

```yaml
- name: Set up JDK
  uses: actions/setup-java@v3
  with:
    java-version: '17'
    distribution: 'temurin'
    cache: 'gradle'
```

## References
[actions/setup-java#caching-packages-dependencies](https://github.com/actions/setup-java#caching-packages-dependencies)