### PR TITLE
Remove Unused `HiddenHttpMethodFilter`

### DIFF
--- a/servlet/java-configuration/hello-mvc-security/gradle/gretty.gradle
+++ b/servlet/java-configuration/hello-mvc-security/gradle/gretty.gradle
@@ -5,6 +5,23 @@ gretty {
 	integrationTestTask = 'integrationTest'
 }
 
+// In Gretty version 3.x, it was possible to run the appRun task without the /src/main/webapp directory.
+// However, strangely, in version 4.x, this directory is required.
+task createWebAppDir {
+	doLast {
+		def webAppDir = new File(project.projectDir, '/src/main/webapp')
+		if (!webAppDir.exists()) {
+			webAppDir.mkdirs()
+		}
+	}
+}
+
+project.afterEvaluate {
+	tasks.named('appRun').configure {
+		dependsOn createWebAppDir
+	}
+}
+
 Task prepareAppServerForIntegrationTests = project.tasks.create('prepareAppServerForIntegrationTests') {
 	group = 'Verification'
 	description = 'Prepares the app server for integration tests'

--- a/servlet/java-configuration/hello-mvc-security/src/main/java/example/MvcWebApplicationInitializer.java
+++ b/servlet/java-configuration/hello-mvc-security/src/main/java/example/MvcWebApplicationInitializer.java
@@ -16,9 +16,6 @@
 
 package example;
 
-import jakarta.servlet.Filter;
-
-import org.springframework.web.filter.HiddenHttpMethodFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
 public class MvcWebApplicationInitializer extends AbstractAnnotationConfigDispatcherServletInitializer {
@@ -37,10 +34,4 @@ public class MvcWebApplicationInitializer extends AbstractAnnotationConfigDispat
 	protected String[] getServletMappings() {
 		return new String[] { "/" };
 	}
-
-	@Override
-	protected Filter[] getServletFilters() {
-		return new Filter[] { new HiddenHttpMethodFilter() };
-	}
-
 }


### PR DESCRIPTION
I have modified the hello-mvc-security example.

1. Remove Unused `HiddenHttpMethodFilter`
2. Gretty 4.x Requirement: Gretty 4.x requires the `/src/main/webapp` path. This prevents failure when running the example project with the appRun task.

* https://github.com/spring-projects/spring-security-samples/issues/167
* https://github.com/gretty-gradle-plugin/gretty/issues/298

thanks.