### PR TITLE
Remove symlink files for libs.versions.toml in sub-sample projects

### DIFF
--- a/reactive/rsocket/hello-security/gradle/libs.versions.toml
+++ b/reactive/rsocket/hello-security/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../gradle/libs.versions.toml

--- a/reactive/rsocket/hello-security/settings.gradle
+++ b/reactive/rsocket/hello-security/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux-fn/hello-security/gradle/libs.versions.toml
+++ b/reactive/webflux-fn/hello-security/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../gradle/libs.versions.toml

--- a/reactive/webflux-fn/hello-security/settings.gradle
+++ b/reactive/webflux-fn/hello-security/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux-fn/hello/gradle/libs.versions.toml
+++ b/reactive/webflux-fn/hello/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../gradle/libs.versions.toml

--- a/reactive/webflux-fn/hello/settings.gradle
+++ b/reactive/webflux-fn/hello/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/authentication/one-time-token/magic-link/gradle/libs.versions.toml
+++ b/reactive/webflux/java/authentication/one-time-token/magic-link/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/authentication/one-time-token/magic-link/settings.gradle
+++ b/reactive/webflux/java/authentication/one-time-token/magic-link/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/authentication/username-password/form/gradle/libs.versions.toml
+++ b/reactive/webflux/java/authentication/username-password/form/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/authentication/username-password/form/settings.gradle
+++ b/reactive/webflux/java/authentication/username-password/form/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/authentication/x509/gradle/libs.versions.toml
+++ b/reactive/webflux/java/authentication/x509/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/authentication/x509/settings.gradle
+++ b/reactive/webflux/java/authentication/x509/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/hello-security-explicit/gradle/libs.versions.toml
+++ b/reactive/webflux/java/hello-security-explicit/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/hello-security-explicit/settings.gradle
+++ b/reactive/webflux/java/hello-security-explicit/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/hello-security/gradle/libs.versions.toml
+++ b/reactive/webflux/java/hello-security/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/hello-security/settings.gradle
+++ b/reactive/webflux/java/hello-security/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/hello/gradle/libs.versions.toml
+++ b/reactive/webflux/java/hello/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/hello/settings.gradle
+++ b/reactive/webflux/java/hello/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/method/gradle/libs.versions.toml
+++ b/reactive/webflux/java/method/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/method/settings.gradle
+++ b/reactive/webflux/java/method/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/oauth2/login/gradle/libs.versions.toml
+++ b/reactive/webflux/java/oauth2/login/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/oauth2/login/settings.gradle
+++ b/reactive/webflux/java/oauth2/login/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/oauth2/resource-server/gradle/libs.versions.toml
+++ b/reactive/webflux/java/oauth2/resource-server/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/oauth2/resource-server/settings.gradle
+++ b/reactive/webflux/java/oauth2/resource-server/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/oauth2/webclient/gradle/libs.versions.toml
+++ b/reactive/webflux/java/oauth2/webclient/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/oauth2/webclient/settings.gradle
+++ b/reactive/webflux/java/oauth2/webclient/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/java/session-management/maximum-sessions/gradle/libs.versions.toml
+++ b/reactive/webflux/java/session-management/maximum-sessions/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/java/session-management/maximum-sessions/settings.gradle
+++ b/reactive/webflux/java/session-management/maximum-sessions/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/reactive/webflux/kotlin/hello-security/gradle/libs.versions.toml
+++ b/reactive/webflux/kotlin/hello-security/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/reactive/webflux/kotlin/hello-security/settings.gradle
+++ b/reactive/webflux/kotlin/hello-security/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/aspectj/gradle/libs.versions.toml
+++ b/servlet/java-configuration/aspectj/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/aspectj/settings.gradle
+++ b/servlet/java-configuration/aspectj/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/authentication/preauth/gradle/libs.versions.toml
+++ b/servlet/java-configuration/authentication/preauth/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/authentication/preauth/settings.gradle
+++ b/servlet/java-configuration/authentication/preauth/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/authentication/remember-me/gradle/libs.versions.toml
+++ b/servlet/java-configuration/authentication/remember-me/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/authentication/remember-me/settings.gradle
+++ b/servlet/java-configuration/authentication/remember-me/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/authentication/username-password/form/gradle/libs.versions.toml
+++ b/servlet/java-configuration/authentication/username-password/form/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/authentication/username-password/form/settings.gradle
+++ b/servlet/java-configuration/authentication/username-password/form/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/authentication/username-password/in-memory/gradle/libs.versions.toml
+++ b/servlet/java-configuration/authentication/username-password/in-memory/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/authentication/username-password/in-memory/settings.gradle
+++ b/servlet/java-configuration/authentication/username-password/in-memory/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/authentication/username-password/jdbc/gradle/libs.versions.toml
+++ b/servlet/java-configuration/authentication/username-password/jdbc/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/authentication/username-password/jdbc/settings.gradle
+++ b/servlet/java-configuration/authentication/username-password/jdbc/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/authentication/username-password/ldap/gradle/libs.versions.toml
+++ b/servlet/java-configuration/authentication/username-password/ldap/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/authentication/username-password/ldap/settings.gradle
+++ b/servlet/java-configuration/authentication/username-password/ldap/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/authentication/x509/gradle/libs.versions.toml
+++ b/servlet/java-configuration/authentication/x509/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/authentication/x509/settings.gradle
+++ b/servlet/java-configuration/authentication/x509/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/data/gradle/libs.versions.toml
+++ b/servlet/java-configuration/data/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/data/settings.gradle
+++ b/servlet/java-configuration/data/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/hello-mvc-security/gradle/libs.versions.toml
+++ b/servlet/java-configuration/hello-mvc-security/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/hello-mvc-security/settings.gradle
+++ b/servlet/java-configuration/hello-mvc-security/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/hello-security-explicit/gradle/libs.versions.toml
+++ b/servlet/java-configuration/hello-security-explicit/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/hello-security-explicit/settings.gradle
+++ b/servlet/java-configuration/hello-security-explicit/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/hello-security/gradle/libs.versions.toml
+++ b/servlet/java-configuration/hello-security/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/hello-security/settings.gradle
+++ b/servlet/java-configuration/hello-security/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/max-sessions/gradle/libs.versions.toml
+++ b/servlet/java-configuration/max-sessions/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/max-sessions/settings.gradle
+++ b/servlet/java-configuration/max-sessions/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/java-configuration/saml2/login/gradle/libs.versions.toml
+++ b/servlet/java-configuration/saml2/login/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/java-configuration/saml2/login/settings.gradle
+++ b/servlet/java-configuration/saml2/login/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/aot/data/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/aot/data/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/aot/data/settings.gradle
+++ b/servlet/spring-boot/java/aot/data/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/authentication/one-time-token/magic-link/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/authentication/one-time-token/magic-link/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/authentication/one-time-token/magic-link/settings.gradle
+++ b/servlet/spring-boot/java/authentication/one-time-token/magic-link/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/authentication/username-password/compromised-password-checker/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/authentication/username-password/compromised-password-checker/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/authentication/username-password/compromised-password-checker/settings.gradle
+++ b/servlet/spring-boot/java/authentication/username-password/compromised-password-checker/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/authentication/username-password/mfa/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/authentication/username-password/mfa/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/authentication/username-password/mfa/settings.gradle
+++ b/servlet/spring-boot/java/authentication/username-password/mfa/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/authentication/username-password/user-details-service/custom-user/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/authentication/username-password/user-details-service/custom-user/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/authentication/username-password/user-details-service/custom-user/settings.gradle
+++ b/servlet/spring-boot/java/authentication/username-password/user-details-service/custom-user/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/cas/login/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/cas/login/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/cas/login/settings.gradle
+++ b/servlet/spring-boot/java/cas/login/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/data/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/data/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/data/settings.gradle
+++ b/servlet/spring-boot/java/data/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/hello-security-explicit/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/hello-security-explicit/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/hello-security-explicit/settings.gradle
+++ b/servlet/spring-boot/java/hello-security-explicit/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/hello-security/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/hello-security/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/hello-security/settings.gradle
+++ b/servlet/spring-boot/java/hello-security/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/hello/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/hello/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/hello/settings.gradle
+++ b/servlet/spring-boot/java/hello/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/jwt/login/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/jwt/login/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/jwt/login/settings.gradle
+++ b/servlet/spring-boot/java/jwt/login/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/ldap/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/ldap/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/ldap/settings.gradle
+++ b/servlet/spring-boot/java/ldap/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/oauth2/authorization-server/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/oauth2/authorization-server/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/oauth2/authorization-server/settings.gradle
+++ b/servlet/spring-boot/java/oauth2/authorization-server/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/oauth2/login/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/oauth2/login/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/oauth2/login/settings.gradle
+++ b/servlet/spring-boot/java/oauth2/login/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/oauth2/resource-server/hello-security/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/oauth2/resource-server/hello-security/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/oauth2/resource-server/hello-security/settings.gradle
+++ b/servlet/spring-boot/java/oauth2/resource-server/hello-security/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/oauth2/resource-server/jwe/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/oauth2/resource-server/jwe/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/oauth2/resource-server/jwe/settings.gradle
+++ b/servlet/spring-boot/java/oauth2/resource-server/jwe/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/oauth2/resource-server/multi-tenancy/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/oauth2/resource-server/multi-tenancy/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/oauth2/resource-server/multi-tenancy/settings.gradle
+++ b/servlet/spring-boot/java/oauth2/resource-server/multi-tenancy/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/oauth2/resource-server/opaque/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/oauth2/resource-server/opaque/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/oauth2/resource-server/opaque/settings.gradle
+++ b/servlet/spring-boot/java/oauth2/resource-server/opaque/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/oauth2/resource-server/static/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/oauth2/resource-server/static/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/oauth2/resource-server/static/settings.gradle
+++ b/servlet/spring-boot/java/oauth2/resource-server/static/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/oauth2/webclient/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/oauth2/webclient/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/oauth2/webclient/settings.gradle
+++ b/servlet/spring-boot/java/oauth2/webclient/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/observability/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/observability/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/observability/settings.gradle
+++ b/servlet/spring-boot/java/observability/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/saml2/custom-urls/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/saml2/custom-urls/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/saml2/custom-urls/settings.gradle
+++ b/servlet/spring-boot/java/saml2/custom-urls/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/saml2/login-single-tenant/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/saml2/login-single-tenant/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/saml2/login-single-tenant/settings.gradle
+++ b/servlet/spring-boot/java/saml2/login-single-tenant/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/saml2/login/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/saml2/login/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/saml2/login/settings.gradle
+++ b/servlet/spring-boot/java/saml2/login/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/saml2/refreshable-metadata/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/saml2/refreshable-metadata/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/saml2/refreshable-metadata/settings.gradle
+++ b/servlet/spring-boot/java/saml2/refreshable-metadata/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/saml2/saml-extension-federation/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/saml2/saml-extension-federation/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/saml2/saml-extension-federation/settings.gradle
+++ b/servlet/spring-boot/java/saml2/saml-extension-federation/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/session-management/maximum-sessions-prevent-login/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/session-management/maximum-sessions-prevent-login/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/session-management/maximum-sessions-prevent-login/settings.gradle
+++ b/servlet/spring-boot/java/session-management/maximum-sessions-prevent-login/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/java/session-management/maximum-sessions/gradle/libs.versions.toml
+++ b/servlet/spring-boot/java/session-management/maximum-sessions/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/java/session-management/maximum-sessions/settings.gradle
+++ b/servlet/spring-boot/java/session-management/maximum-sessions/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/spring-boot/kotlin/hello-security/gradle/libs.versions.toml
+++ b/servlet/spring-boot/kotlin/hello-security/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/spring-boot/kotlin/hello-security/settings.gradle
+++ b/servlet/spring-boot/kotlin/hello-security/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/xml/java/contacts/gradle/libs.versions.toml
+++ b/servlet/xml/java/contacts/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/xml/java/contacts/settings.gradle
+++ b/servlet/xml/java/contacts/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/xml/java/dms/gradle/libs.versions.toml
+++ b/servlet/xml/java/dms/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/xml/java/dms/settings.gradle
+++ b/servlet/xml/java/dms/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/xml/java/helloworld/gradle/libs.versions.toml
+++ b/servlet/xml/java/helloworld/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/xml/java/helloworld/settings.gradle
+++ b/servlet/xml/java/helloworld/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/xml/java/preauth/gradle/libs.versions.toml
+++ b/servlet/xml/java/preauth/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../gradle/libs.versions.toml

--- a/servlet/xml/java/preauth/settings.gradle
+++ b/servlet/xml/java/preauth/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/servlet/xml/java/saml2/login-logout/gradle/libs.versions.toml
+++ b/servlet/xml/java/saml2/login-logout/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../../../../../gradle/libs.versions.toml

--- a/servlet/xml/java/saml2/login-logout/settings.gradle
+++ b/servlet/xml/java/saml2/login-logout/settings.gradle
@@ -6,3 +6,11 @@ pluginManagement {
         maven { url "https://repo.spring.io/snapshot" }
     }
 }
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../../../../gradle/libs.versions.toml"))
+        }
+    }
+}


### PR DESCRIPTION
I specified the relative path of the root toml file in the settings.gradle file of each sub-example project. 

This method ensures compatibility with non-Linux/UNIX OS environments where symbolic links are not available

The toml files in the following two examples are actual files, not symbolic links, so I excluded them:

* ./servlet/spring-boot/java/oauth2/resource-server/restclient/gradle/libs.versions.toml
* ./servlet/spring-boot/java/oauth2/restclient/gradle/libs.versions.toml


**Related Issues**
* #300 
